### PR TITLE
#12 Fixed bug with nested transactions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ test {
     useJUnitPlatform()
 }
 
+// Required so that Kotlin generates java 11 bytecode
+compileKotlin.kotlinOptions.jvmTarget = JavaVersion.VERSION_11
+compileTestKotlin.kotlinOptions.jvmTarget = JavaVersion.VERSION_11
+
 sourceSets {
     main {
         kotlin.srcDir "src/main/kotlin"
@@ -60,7 +64,9 @@ dependencies {
     implementation "com.h2database:h2:1.4.197"
     implementation "org.postgresql:postgresql:42.2.9"
     implementation "com.zaxxer:HikariCP:3.4.2"
-    implementation "org.jetbrains.exposed:exposed:0.17.7"
+    implementation "org.jetbrains.exposed:exposed-core:$exposed_version"
+    implementation "org.jetbrains.exposed:exposed-dao:$exposed_version"
+    implementation "org.jetbrains.exposed:exposed-jdbc:$exposed_version"
     implementation "org.flywaydb:flyway-core:6.1.4"
 
     testImplementation "io.ktor:ktor-server-test-host:$ktor_version"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
+kotlin.code.style=official
 logback_version=1.2.1
 ktor_version=1.4.1
-kotlin.code.style=official
+exposed_version=0.27.1
 kotlin_version=1.4.10
 koin_version=2.1.6
 junit_version=5.6.0

--- a/src/main/kotlin/test/ktortemplate/conf/DevEnvironmentConfigurator.kt
+++ b/src/main/kotlin/test/ktortemplate/conf/DevEnvironmentConfigurator.kt
@@ -8,8 +8,11 @@ import org.koin.core.module.Module
 import org.koin.dsl.module
 import test.ktortemplate.conf.database.DatabaseConnection
 import test.ktortemplate.core.persistance.CarRepository
+import test.ktortemplate.core.persistance.PartRepository
 import test.ktortemplate.core.persistance.sql.CarMappingsTable
 import test.ktortemplate.core.persistance.sql.CarRepositoryImpl
+import test.ktortemplate.core.persistance.sql.PartMappingsTable
+import test.ktortemplate.core.persistance.sql.PartRepositoryImpl
 import test.ktortemplate.core.service.CarService
 import test.ktortemplate.core.service.CarServiceImpl
 import javax.sql.DataSource
@@ -28,6 +31,7 @@ class DevEnvironmentConfigurator(private val environment: ApplicationEnvironment
 
     private fun initServicesAndRepos() = module {
         single<CarRepository> { CarRepositoryImpl() }
+        single<PartRepository> { PartRepositoryImpl() }
         single<CarService> { CarServiceImpl() }
     }
 
@@ -56,6 +60,7 @@ class DevEnvironmentConfigurator(private val environment: ApplicationEnvironment
     private fun bootstrapDatabase(dbc: DatabaseConnection) {
         dbc.query {
             SchemaUtils.create(CarMappingsTable)
+            SchemaUtils.create(PartMappingsTable)
         }
     }
 }

--- a/src/main/kotlin/test/ktortemplate/conf/database/DatabaseConnection.kt
+++ b/src/main/kotlin/test/ktortemplate/conf/database/DatabaseConnection.kt
@@ -10,8 +10,6 @@ class DatabaseConnection(private val dataSource: DataSource) {
     }
 
     fun <T> query(block: () -> T): T = transaction(database) {
-        val blockReturn = block()
-        commit()
-        blockReturn
+        block()
     }
 }

--- a/src/main/kotlin/test/ktortemplate/core/model/Part.kt
+++ b/src/main/kotlin/test/ktortemplate/core/model/Part.kt
@@ -1,0 +1,5 @@
+package test.ktortemplate.core.model
+
+data class Part(val partNo: Long, val manufacturer: String, val desc: String)
+
+data class RegisterPartReplacementCommand(val carId: Long, val parts: List<Part>)

--- a/src/main/kotlin/test/ktortemplate/core/persistance/PartRepository.kt
+++ b/src/main/kotlin/test/ktortemplate/core/persistance/PartRepository.kt
@@ -1,0 +1,11 @@
+package test.ktortemplate.core.persistance
+
+import test.ktortemplate.core.model.Part
+
+interface PartRepository {
+    fun list(): List<Part>
+    fun delete(partNo: Long)
+    fun count(): Int
+    fun getPartsForCar(carId: Long): List<Part>
+    fun addPartToCar(carId: Long, part: Part): Part
+}

--- a/src/main/kotlin/test/ktortemplate/core/persistance/sql/CarMappingsTable.kt
+++ b/src/main/kotlin/test/ktortemplate/core/persistance/sql/CarMappingsTable.kt
@@ -1,9 +1,8 @@
 package test.ktortemplate.core.persistance.sql
 
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.dao.id.LongIdTable
 
-internal object CarMappingsTable : Table("car") {
-    val id = long("id").primaryKey().autoIncrement()
+internal object CarMappingsTable : LongIdTable("car") {
     val brand = text("brand")
     val model = text("model")
 }

--- a/src/main/kotlin/test/ktortemplate/core/persistance/sql/CarRepositoryImpl.kt
+++ b/src/main/kotlin/test/ktortemplate/core/persistance/sql/CarRepositoryImpl.kt
@@ -34,13 +34,13 @@ class CarRepositoryImpl : CarRepository, KoinComponent {
                 it[model] = car.model
             } get CarMappingsTable.id
 
-            Car(newCarId, car.brand, car.model)
+            Car(newCarId.value, car.brand, car.model)
         }
     }
 
     override fun count(): Int {
         return dbc.query {
-            CarMappingsTable.selectAll().count()
+            CarMappingsTable.selectAll().count().toInt()
         }
     }
 
@@ -58,7 +58,7 @@ class CarRepositoryImpl : CarRepository, KoinComponent {
 
     private fun resultToModel(rstRow: ResultRow): Car {
         return Car(
-            rstRow[CarMappingsTable.id],
+            rstRow[CarMappingsTable.id].value,
             rstRow[CarMappingsTable.brand],
             rstRow[CarMappingsTable.model]
         )

--- a/src/main/kotlin/test/ktortemplate/core/persistance/sql/PartMappingsTable.kt
+++ b/src/main/kotlin/test/ktortemplate/core/persistance/sql/PartMappingsTable.kt
@@ -1,0 +1,17 @@
+package test.ktortemplate.core.persistance.sql
+
+import org.jetbrains.exposed.sql.ReferenceOption
+import org.jetbrains.exposed.sql.Table
+
+internal object PartMappingsTable : Table("part") {
+    val partNo = long("part_no")
+    val carId = reference("car_id", CarMappingsTable.id, ReferenceOption.CASCADE)
+    val manufacturer = text("manufacturer")
+    val desc = text("desc")
+
+    override val primaryKey = PrimaryKey(partNo)
+
+    init {
+        uniqueIndex(partNo, carId)
+    }
+}

--- a/src/main/kotlin/test/ktortemplate/core/persistance/sql/PartRepositoryImpl.kt
+++ b/src/main/kotlin/test/ktortemplate/core/persistance/sql/PartRepositoryImpl.kt
@@ -1,0 +1,54 @@
+package test.ktortemplate.core.persistance.sql
+
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.selectAll
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+import test.ktortemplate.conf.database.DatabaseConnection
+import test.ktortemplate.core.model.Part
+import test.ktortemplate.core.persistance.PartRepository
+
+internal class PartRepositoryImpl : PartRepository, KoinComponent {
+
+    private val dbc: DatabaseConnection by inject()
+
+    override fun list(): List<Part> {
+        return dbc.query { PartMappingsTable.selectAll().map { toModel(it) } }
+    }
+
+    override fun delete(partNo: Long) {
+        dbc.query { PartMappingsTable.deleteWhere { PartMappingsTable.partNo eq partNo } }
+    }
+
+    override fun count(): Int {
+        return dbc.query { PartMappingsTable.selectAll().count().toInt() }
+    }
+
+    override fun getPartsForCar(carId: Long): List<Part> {
+        return dbc.query { PartMappingsTable.select { PartMappingsTable.carId eq carId }.map { toModel(it) } }
+    }
+
+    override fun addPartToCar(carId: Long, part: Part): Part {
+        dbc.query {
+            PartMappingsTable.insert {
+                it[PartMappingsTable.carId] = carId
+                it[partNo] = part.partNo
+                it[desc] = part.desc
+                it[manufacturer] = part.desc
+            }
+        }
+
+        return part
+    }
+
+    private fun toModel(row: ResultRow): Part {
+        return Part(
+            partNo = row[PartMappingsTable.partNo],
+            manufacturer = row[PartMappingsTable.manufacturer],
+            desc = row[PartMappingsTable.desc]
+        )
+    }
+}

--- a/src/main/kotlin/test/ktortemplate/core/service/CarService.kt
+++ b/src/main/kotlin/test/ktortemplate/core/service/CarService.kt
@@ -2,8 +2,11 @@ package test.ktortemplate.core.service
 
 import test.ktortemplate.core.model.Car
 import test.ktortemplate.core.model.CarSaveCommand
+import test.ktortemplate.core.model.RegisterPartReplacementCommand
 
 interface CarService {
     fun getCarById(carId: Long): Car?
     fun insertNewCar(newCar: CarSaveCommand): Car
+
+    fun registerPartReplacement(replacedParts: RegisterPartReplacementCommand): Car
 }

--- a/src/main/kotlin/test/ktortemplate/core/service/CarServiceImpl.kt
+++ b/src/main/kotlin/test/ktortemplate/core/service/CarServiceImpl.kt
@@ -2,15 +2,34 @@ package test.ktortemplate.core.service
 
 import org.koin.core.KoinComponent
 import org.koin.core.inject
+import test.ktortemplate.conf.database.DatabaseConnection
 import test.ktortemplate.core.model.Car
 import test.ktortemplate.core.model.CarSaveCommand
+import test.ktortemplate.core.model.Part
+import test.ktortemplate.core.model.RegisterPartReplacementCommand
 import test.ktortemplate.core.persistance.CarRepository
+import test.ktortemplate.core.persistance.PartRepository
 
 class CarServiceImpl : KoinComponent, CarService {
 
     private val carRepository: CarRepository by inject()
+    private val partRepository: PartRepository by inject()
+    private val dbc: DatabaseConnection by inject()
 
     override fun getCarById(carId: Long): Car? = this.carRepository.getById(carId)
 
     override fun insertNewCar(newCar: CarSaveCommand): Car = this.carRepository.save(newCar)
+
+    override fun registerPartReplacement(replacedParts: RegisterPartReplacementCommand): Car {
+        // this runs the operation as a single transaction
+        return dbc.query {
+            val car = carRepository.getById(replacedParts.carId)
+            requireNotNull(car) { "Car must exist" }
+            for (part: Part in replacedParts.parts) {
+                partRepository.addPartToCar(car.id, part)
+            }
+
+            car
+        }
+    }
 }

--- a/src/test/kotlin/test/ktortemplate/core/TestUtils.kt
+++ b/src/test/kotlin/test/ktortemplate/core/TestUtils.kt
@@ -21,8 +21,11 @@ import org.koin.dsl.module
 import test.ktortemplate.conf.database.DatabaseConnection
 import test.ktortemplate.core.httphandler.defaultRoutes
 import test.ktortemplate.core.persistance.CarRepository
+import test.ktortemplate.core.persistance.PartRepository
 import test.ktortemplate.core.persistance.sql.CarMappingsTable
 import test.ktortemplate.core.persistance.sql.CarRepositoryImpl
+import test.ktortemplate.core.persistance.sql.PartMappingsTable
+import test.ktortemplate.core.persistance.sql.PartRepositoryImpl
 import test.ktortemplate.core.service.CarService
 import test.ktortemplate.core.service.CarServiceImpl
 import test.ktortemplate.core.utils.JsonSettings
@@ -31,11 +34,13 @@ import javax.sql.DataSource
 private fun bootstrapDatabase(dbc: DatabaseConnection) {
     dbc.query {
         SchemaUtils.create(CarMappingsTable)
+        SchemaUtils.create(PartMappingsTable)
     }
 }
 
 fun initServicesAndRepos() = module {
     single<CarRepository> { CarRepositoryImpl() }
+    single<PartRepository> { PartRepositoryImpl() }
     single<CarService> { CarServiceImpl() }
 }
 

--- a/src/test/kotlin/test/ktortemplate/core/service/TestCarService.kt
+++ b/src/test/kotlin/test/ktortemplate/core/service/TestCarService.kt
@@ -1,0 +1,104 @@
+package test.ktortemplate.core.service
+
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertThrows
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.test.KoinTest
+import org.koin.test.inject
+import test.ktortemplate.core.initDbCore
+import test.ktortemplate.core.initServicesAndRepos
+import test.ktortemplate.core.model.CarSaveCommand
+import test.ktortemplate.core.model.Part
+import test.ktortemplate.core.model.RegisterPartReplacementCommand
+import test.ktortemplate.core.persistance.CarRepository
+import test.ktortemplate.core.persistance.PartRepository
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestCarService : KoinTest {
+
+    private val carRepository: CarRepository by inject()
+    private val partRepository: PartRepository by inject()
+    private val carService: CarService by inject()
+
+    @BeforeAll
+    fun setup() {
+        val appModules = listOf(
+            initDbCore(),
+            initServicesAndRepos()
+        )
+        startKoin { modules(appModules) }
+    }
+
+    @AfterEach
+    fun cleanDatabase() {
+        val cars = carRepository.list()
+        cars.forEach {
+            carRepository.delete(it.id)
+        }
+        carRepository.count() `should be equal to` 0
+
+        val parts = partRepository.list()
+        parts.forEach {
+            partRepository.delete(it.partNo)
+        }
+        partRepository.count() `should be equal to` 0
+    }
+
+    @AfterAll
+    fun close() {
+        stopKoin()
+    }
+
+    @Test
+    fun `Parts can be added to a car`() {
+        // Given: a car
+        val car = carRepository.save(CarSaveCommand("Mercedes-Benz", "A 180"))
+        val oldPartsCount = partRepository.count()
+
+        // And: a set of parts one of which has a duplicate part number
+        val partReplacement = RegisterPartReplacementCommand(
+            carId = car.id,
+            parts = listOf(
+                Part(partNo = 1L, manufacturer = "Bosch", desc = "Spark plug"),
+                Part(partNo = 2L, manufacturer = "Wurth", desc = "Air conditioner filter"),
+            )
+        )
+
+        // When: a parts replacement is registered it fails
+        carService.registerPartReplacement(partReplacement)
+
+        // Expect: no parts have been associated with the car
+        partRepository.count() `should be equal to` oldPartsCount + partReplacement.parts.size
+    }
+
+    @Test
+    fun `Test that nested transactions rollback as expected`() {
+        // Given: a car
+        val car = carRepository.save(CarSaveCommand("Mercedes-Benz", "A 180"))
+        val oldPartsCount = partRepository.count()
+
+        // And: a set of parts one of which has a duplicate part number
+        val partReplacement = RegisterPartReplacementCommand(
+            carId = car.id,
+            parts = listOf(
+                Part(partNo = 1L, manufacturer = "Bosch", desc = "Spark plug"),
+                Part(partNo = 2L, manufacturer = "Wurth", desc = "Air conditioner filter"),
+                Part(partNo = 1L, manufacturer = "Bosch", desc = "Spark plug") // note the duplicate part
+            )
+        )
+
+        // When: a parts replacement is registered it fails
+        assertThrows<Exception> {
+            carService.registerPartReplacement(partReplacement)
+        }
+
+        // Expect: no parts have been associated with the car
+        partRepository.count() `should be equal to` oldPartsCount
+    }
+}


### PR DESCRIPTION
Added a simple test case with a nested transaction to demonstrate the problem with having the commit in the database connection.
The example is contrived but bear with me:  For the example case we're adding a list of replacement parts to a car in the CarService. This operation should be atomic, meaning if there is any problem storing one of the parts in the list, it should roll back.

The problem is that we are opening a new transaction when we call `DatabaseConnection.query`, and in a scenario where we have nested calls to this method, where in principle you would want to maintain atomicity, the `commit()` icall n that method's body actually commited that sub-transaction.