### PR TITLE
Move dependencies to single file.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,10 +8,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout the repo
+      uses: actions/checkout@v2
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
         java-version: 11
+    - name: Validate Gradle Wrapper
+      uses: gradle/wrapper-validation-action@v1
+    - name: Cache gradle
+      uses: actions/cache@v2.1.0
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('gradle/dependencies.gradle') }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+
     - name: Build with Gradle
       run: ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ group 'com.ktor-template'
 version '0.1'
 
 buildscript {
+    apply from: "$rootDir/gradle/dependencies.gradle"
 
     repositories {
         mavenCentral()
@@ -10,10 +11,10 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.koin:koin-gradle-plugin:$koin_version"
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
-        classpath 'org.jlleitschuh.gradle:ktlint-gradle:9.4.1'
+        classpath deps.plugins.kotlin
+        classpath deps.plugins.koin
+        classpath deps.plugins.shadow
+        classpath deps.plugins.ktlint
     }
 }
 
@@ -22,6 +23,8 @@ apply plugin: 'application'
 apply plugin: 'koin'
 apply plugin: "com.github.johnrengelman.shadow"
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
+
+apply from: "$rootDir/gradle/dependencies.gradle"
 
 repositories {
     mavenCentral()
@@ -48,35 +51,35 @@ sourceSets {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation deps.kotlin.jdk
 
-    implementation "ch.qos.logback:logback-classic:1.2.3"
+    implementation deps.logback
 
-    implementation "io.ktor:ktor-server-netty:$ktor_version"
-    implementation "io.ktor:ktor-jackson:$ktor_version"
-    implementation "io.ktor:ktor-auth:$ktor_version"
+    implementation deps.ktor.serverNetty
+    implementation deps.ktor.jackson
+    implementation deps.ktor.auth
 
-    implementation "org.koin:koin-core:$koin_version"
-    implementation "org.koin:koin-core-ext:$koin_version"
-    implementation "org.koin:koin-ktor:$koin_version"
+    implementation deps.koin.core
+    implementation deps.koin.coreExt
+    implementation deps.koin.ktor
 
     // Database stuff
-    implementation "org.postgresql:postgresql:42.2.17"
-    implementation "com.zaxxer:HikariCP:3.4.5"
-    implementation "org.jetbrains.exposed:exposed-core:$exposed_version"
-    implementation "org.jetbrains.exposed:exposed-dao:$exposed_version"
-    implementation "org.jetbrains.exposed:exposed-jdbc:$exposed_version"
-    implementation "org.flywaydb:flyway-core:7.0.2"
+    implementation deps.postgresql
+    implementation deps.hikari
+    implementation deps.exposed.core
+    implementation deps.exposed.dao
+    implementation deps.exposed.jdbc
+    implementation deps.flyaway
 
-    testImplementation "io.ktor:ktor-server-test-host:$ktor_version"
-    testImplementation "org.koin:koin-test:$koin_version"
-    testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"
-    testImplementation "org.junit.jupiter:junit-jupiter-params:$junit_version"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_version"
-    testImplementation "org.amshove.kluent:kluent:1.61"
-    testImplementation "org.testcontainers:testcontainers:1.14.3"
-    testImplementation "org.testcontainers:junit-jupiter:1.14.3"
-    testImplementation "org.testcontainers:postgresql:1.14.3"
+    testImplementation deps.ktor.test
+    testImplementation deps.koin.test
+    testImplementation deps.junit.api
+    testImplementation deps.junit.params
+    testRuntimeOnly deps.junit.engine
+    testImplementation deps.kluent
+    testImplementation deps.testContainers.core
+    testImplementation deps.testContainers.junit
+    testImplementation deps.testContainers.postgres
 }
 
 test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,0 @@
-kotlin.code.style=official
-logback_version=1.2.1
-ktor_version=1.4.1
-exposed_version=0.27.1
-kotlin_version=1.4.10
-koin_version=2.1.6
-junit_version=5.6.0

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,0 +1,52 @@
+ext.versions = [
+    kotlin: '1.4.10',
+    koin: '2.1.6',
+    ktor: '1.4.1',
+    exposed: '0.27.1',
+    testContainers: '1.14.3',
+    junit: '5.6.0'
+]
+
+ext.deps = [
+    plugins: [
+        kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
+        koin: "org.koin:koin-gradle-plugin:${versions.koin}",
+        shadow: "com.github.jengelman.gradle.plugins:shadow:6.1.0",
+        ktlint: "org.jlleitschuh.gradle:ktlint-gradle:9.4.1",
+    ],
+    kotlin: [
+        jdk: "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
+    ],
+    ktor: [
+        serverNetty: "io.ktor:ktor-server-netty:${versions.ktor}",
+        jackson: "io.ktor:ktor-jackson:${versions.ktor}",
+        auth: "io.ktor:ktor-auth:${versions.ktor}",
+        test: "io.ktor:ktor-server-test-host:${versions.ktor}"
+    ],
+    koin: [
+        core: "org.koin:koin-core:${versions.koin}",
+        coreExt: "org.koin:koin-core-ext:${versions.koin}",
+        ktor: "org.koin:koin-ktor:${versions.koin}",
+        test: "org.koin:koin-test:${versions.koin}"
+    ],
+    exposed: [
+        core: "org.jetbrains.exposed:exposed-core:${versions.exposed}",
+        dao: "org.jetbrains.exposed:exposed-dao:${versions.exposed}",
+        jdbc: "org.jetbrains.exposed:exposed-jdbc:${versions.exposed}",
+    ],
+    testContainers: [
+        core: "org.testcontainers:testcontainers:${versions.testContainers}",
+        junit: "org.testcontainers:junit-jupiter:${versions.testContainers}",
+        postgres: "org.testcontainers:postgresql:${versions.testContainers}"
+    ],
+    logback: "ch.qos.logback:logback-classic:1.2.3",
+    postgresql: "org.postgresql:postgresql:42.2.17",
+    hikari: "com.zaxxer:HikariCP:3.4.5",
+    flyaway: "org.flywaydb:flyway-core:7.0.2",
+    kluent: "org.amshove.kluent:kluent:1.61",
+    junit: [
+        api: "org.junit.jupiter:junit-jupiter-api:${versions.junit}",
+        params: "org.junit.jupiter:junit-jupiter-params:${versions.junit}",
+        engine: "org.junit.jupiter:junit-jupiter-engine:${versions.junit}",
+    ]
+]


### PR DESCRIPTION
This is just an improvement to extract all dependencies to a dedicated file.

The reason for this is to work well with gradle cache on CI environment. We're calculating hash file based on changes, and if we kept using the main `build.gradle` for this which is used for other configuration besides dependencies, any change would resolve in a cache miss since the hash would be different.

