### PR TITLE
#74 - Adding configurable prefix/suffix to SemiStructuredLogFormatter

### DIFF
--- a/ktor-template-core/src/main/kotlin/mobi/waterdog/rest/template/log/SemiStructuredLogFormatter.kt
+++ b/ktor-template-core/src/main/kotlin/mobi/waterdog/rest/template/log/SemiStructuredLogFormatter.kt
@@ -14,6 +14,12 @@ class SemiStructuredLogFormatter : JsonFormatter {
         const val REQUEST_ID_HEADER = "X-Request-Id"
     }
 
+    // Configurable from logback.xml with <jsonSuffix>JSON:</jsonSuffix>
+    var prefix = ""
+    var suffix = ""
+    var jsonPrefix = ""
+    var jsonSuffix = ""
+
     @Serializable
     internal data class LogResponse(
         val timestamp: String,
@@ -44,13 +50,17 @@ class SemiStructuredLogFormatter : JsonFormatter {
 
         // Construct log message
         var str = ""
+        str += prefix
         str += "${json.timestamp} "
         str += "${json.level} ".padEnd(6)
         str += if (requestId != null && requestId.isNotEmpty()) "$requestId " else ""
         str += "${json.message} "
         str = str.padEnd(125) // add padding to the first fields for better readability
         str += if (json.exception != null && json.exception.isNotEmpty()) "${json.exception} " else ""
+        str += jsonPrefix
         str += encodeToString(LogResponse.serializer(), json)
+        str += jsonSuffix
+        str += suffix
         str += "\n"
 
         return str

--- a/ktor-template-tests/src/main/resources/logback.xml
+++ b/ktor-template-tests/src/main/resources/logback.xml
@@ -4,7 +4,9 @@
             <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
                 <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampFormat>
                 <timestampFormatTimezoneId>Etc/UTC</timestampFormatTimezoneId>
-                <jsonFormatter class="mobi.waterdog.rest.template.log.SemiStructuredLogFormatter" />
+                <jsonFormatter class="mobi.waterdog.rest.template.log.SemiStructuredLogFormatter">
+                    <jsonPrefix>JSON:</jsonPrefix>
+                </jsonFormatter>
             </layout>
         </encoder>
     </appender>


### PR DESCRIPTION
Example with **JSON** prefix:
```
2020-11-06T12:30:31.421Z INFO  ff0dbf3c-856a-493a-8ffe-966d8d844824 200 OK: POST - /v1/cars                                  JSON:{"timestamp":"2020-11-06T12:30:31.421Z","level":"INFO","thread":"DefaultDispatcher-worker-1 @request#2","logger":"ktor.test","message":"200 OK: POST - /v1/cars","metadata":{"X-Request-Id":"ff0dbf3c-856a-493a-8ffe-966d8d844824"}}
```

Closes #74 